### PR TITLE
chore: unpin sinon and use 6.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"git-log-parser": "^1.2.0",
 		"nyc": "^12.0.2",
 		"semantic-release": "^15.7.0",
-		"sinon": "6.0.0",
+		"sinon": "^6.1.3",
 		"tempy": "^0.2.1",
 		"xo": "^0.21.0"
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Travis should be more stable now, I think this was set because of a false failure.
